### PR TITLE
Fixes build on OS X with Clang

### DIFF
--- a/config/Compiler.cmake
+++ b/config/Compiler.cmake
@@ -24,6 +24,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 		-Wno-missing-prototypes
 		-Wno-documentation-unknown-command
 		-Wno-switch-enum
+		-Wno-deprecated-declarations
+		-Wno-missing-noreturn
 	)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	add_definitions(

--- a/implement/oglplus/error/info.inl
+++ b/implement/oglplus/error/info.inl
@@ -9,6 +9,7 @@
 #if !OGLPLUS_LINK_LIBRARY || defined(OGLPLUS_IMPLEMENTING_LIBRARY)
 #include <oglplus/enum/types.hpp>
 #include <string>
+#include <vector>
 #endif
 
 #ifndef GL_SHADER

--- a/include/eagine/cstr_ref.hpp
+++ b/include/eagine/cstr_ref.hpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <cassert>
 #include <iosfwd>
+#include <ostream>
 
 namespace eagine {
 


### PR DESCRIPTION
- OS X version: El Capitan 10.11.3
- Clang version: Apple LLVM version 7.0.2 (clang-700.1.81)
