### PR TITLE
Changes to OS X + Clang build

### DIFF
--- a/config/Compiler.cmake
+++ b/config/Compiler.cmake
@@ -24,8 +24,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 		-Wno-missing-prototypes
 		-Wno-documentation-unknown-command
 		-Wno-switch-enum
-		-Wno-deprecated-declarations
-		-Wno-missing-noreturn
 	)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	add_definitions(

--- a/example/oglplus/example/main_glut.cpp
+++ b/example/oglplus/example/main_glut.cpp
@@ -24,6 +24,11 @@
 #include <iostream>
 #include <cassert>
 
+#if defined(__APPLE__) && __APPLE__ && defined(__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 class single_glut_context
 {
 private:
@@ -81,6 +86,11 @@ public:
 		instance_ptr() = nullptr;
 	}
 
+#if defined(__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
 	void quit(void)
 	{
 #ifdef FREEGLUT
@@ -89,6 +99,10 @@ public:
 		exit(0);
 #endif
 	}
+
+#if defined(__clang__)
+# pragma clang diagnostic pop
+#endif
 
 private:
 	void close(void)
@@ -223,3 +237,6 @@ int example_main(
 	return 0;
 }
 
+#if defined(__APPLE__) && __APPLE__ && defined(__clang__)
+# pragma clang diagnostic pop
+#endif


### PR DESCRIPTION
Regarding my previous PR ([#5](https://github.com/matus-chochlik/oglplu2/pull/5)):

I'm not sure how to detect OS X version, but I think it's quite safe to just check _APPLE_ since according to the warning it has been deprecated since OS X 10.9 Mavericks. I kind of doubt very many people use anything older than that, especially since upgrading to newer versions is either free or very cheap. But I agree with you, if it's easy to detect the version, then why not make it more narrow.

Here is the error message:

`/Users/deranen/Programming/oglplu2/example/oglplus/example/main_glut.cpp:67:3: error: 
      'glutDisplayFunc' is deprecated: first deprecated in OS X 10.9
      [-Werror,-Wdeprecated-declarations]
                glutDisplayFunc(&display_func);
                ^
/System/Library/Frameworks/GLUT.framework/Headers/glut.h:505:22: note: 'glutDisplayFunc' has been
      explicitly marked deprecated here
extern void APIENTRY glutDisplayFunc(void (*func)(void)) OPENGL_DEPRECATED(10_0, 10_9);`

It is not possible to get rid of the deprecated warning by wrapping the pragmas around the include statements, it needs to be around the code which uses the functions. It seems like every single glut function is deprecated, so I wrapped the whole file.

The noreturn warning could probably be fixed instead of suppressing it, but I'll leave that to you if you want to do it.

If you want me to make any changes before merging then just tell me.
